### PR TITLE
Multicluster Treeview 

### DIFF
--- a/src/utils/contexts/KubevirtPluginContext.tsx
+++ b/src/utils/contexts/KubevirtPluginContext.tsx
@@ -34,6 +34,7 @@ export type KubevirtPluginData = {
   currentNamespace?: string;
   dynamicPluginSDK: typeof OpenshiftDynamicPluginSDK;
   getResourceUrl: typeof getResourceUrl;
+  getResourceUrlOverride: (cluster?: string) => typeof getResourceUrl;
   getStandaloneVMConsoleUrl: typeof getStandaloneVMConsoleUrl;
   k8sAPIPath: string;
   supportsMulticluster: boolean;
@@ -47,6 +48,7 @@ const defaultContext: KubevirtPluginData = {
   clusterScope: { ClusterScope, withCluster },
   dynamicPluginSDK: OpenshiftDynamicPluginSDK,
   getResourceUrl,
+  getResourceUrlOverride: () => getResourceUrl,
   getStandaloneVMConsoleUrl,
   k8sAPIPath: '/api/kubernetes',
   supportsMulticluster: false,

--- a/src/utils/hooks/constants.ts
+++ b/src/utils/hooks/constants.ts
@@ -6,3 +6,5 @@ export const EVENT_LOCALSTORAGE = 'event_localstorage';
 
 export const ALL_CLUSTERS_SESSION_KEY = '#ALL_CLUSTERS#';
 export const ALL_CLUSTERS = 'All clusters';
+
+export const LOCAL_CLUSTER = 'local-cluster';

--- a/src/utils/hooks/constants.ts
+++ b/src/utils/hooks/constants.ts
@@ -3,3 +3,6 @@ export const ALL_NAMESPACES = 'all-namespaces';
 export const ALL_PROJECTS = 'All projects';
 
 export const EVENT_LOCALSTORAGE = 'event_localstorage';
+
+export const ALL_CLUSTERS_SESSION_KEY = '#ALL_CLUSTERS#';
+export const ALL_CLUSTERS = 'All clusters';

--- a/src/utils/hooks/useKubevirtDataPod/hooks/useKubevirtDataPodHealth.ts
+++ b/src/utils/hooks/useKubevirtDataPod/hooks/useKubevirtDataPodHealth.ts
@@ -1,24 +1,24 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 
 import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { PROXY_KUBEVIRT_URL, PROXY_KUBEVIRT_URL_HEALTH_PATH } from '../utils/constants';
 
 const useKubevirtDataPodHealth = (): boolean | null => {
-  const alive = useRef<boolean>(null);
+  const [alive, setAlive] = useState<boolean>(null);
   useEffect(() => {
     const fetch = async () => {
       try {
         const res = await consoleFetch(`${PROXY_KUBEVIRT_URL}${PROXY_KUBEVIRT_URL_HEALTH_PATH}`);
-        alive.current = res.ok;
+        setAlive(res.ok);
       } catch {
-        alive.current = false;
+        setAlive(false);
       }
     };
 
-    alive.current === null && fetch();
-  }, []);
+    alive === null && fetch();
+  }, [alive]);
 
-  return alive.current;
+  return alive;
 };
 export default useKubevirtDataPodHealth;

--- a/src/utils/hooks/useKubevirtDataPod/hooks/useKubevirtDataPodHealth.ts
+++ b/src/utils/hooks/useKubevirtDataPod/hooks/useKubevirtDataPodHealth.ts
@@ -1,24 +1,25 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 
 import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { PROXY_KUBEVIRT_URL, PROXY_KUBEVIRT_URL_HEALTH_PATH } from '../utils/constants';
 
 const useKubevirtDataPodHealth = (): boolean | null => {
-  const alive = useRef<boolean>(null);
+  const [alive, setAlive] = useState<boolean>(null);
   useEffect(() => {
+    debugger;
     const fetch = async () => {
       try {
         const res = await consoleFetch(`${PROXY_KUBEVIRT_URL}${PROXY_KUBEVIRT_URL_HEALTH_PATH}`);
-        alive.current = res.ok;
+        setAlive(res.ok);
       } catch {
-        alive.current = false;
+        setAlive(false);
       }
     };
 
-    alive.current === null && fetch();
-  }, []);
+    alive === null && fetch();
+  }, [alive]);
 
-  return alive.current;
+  return alive;
 };
 export default useKubevirtDataPodHealth;

--- a/src/utils/hooks/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource.ts
@@ -46,7 +46,7 @@ const useKubevirtWatchResource: UseKubevirtWatchResource = <T>(watchOptions, fil
     useKubevirtDataPod<T>(shouldUseProxyPod ? watchOptions : {}, filterOptions);
 
   useEffect(() => {
-    if (supportsMulticluster || shouldUseProxyPod !== null) {
+    if (shouldUseProxyPod !== null) {
       const singleClusterResult = shouldUseProxyPod
         ? [resourceKubevirtDataPod, loadedKubevirtDataPod, loadErrorKubevirtDataPod]
         : [resourceK8sWatch, loadedK8sWatch, loadErrorK8sWatch];

--- a/src/utils/hooks/useMultiClusterNamespaces.ts
+++ b/src/utils/hooks/useMultiClusterNamespaces.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-ui/kubevirt-api/console';
+import { MulticlusterResource } from '@kubevirt-utils/contexts/KubevirtPluginContext';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
+
+import useKubevirtWatchResource from './useKubevirtWatchResource';
+
+type MultiClusterNamespaces = () => [MulticlusterResource<K8sResourceCommon[]>, boolean, any];
+
+const useMultiClusterNamespaces: MultiClusterNamespaces = () => {
+  const [namespaceData, loaded, error] = useKubevirtWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: modelToGroupVersionKind(NamespaceModel),
+    isList: true,
+    limit: OBJECTS_FETCHING_LIMIT,
+  });
+  return [namespaceData, loaded, error];
+};
+
+export default useMultiClusterNamespaces;

--- a/src/utils/hooks/useMultiClusterNamespaces.ts
+++ b/src/utils/hooks/useMultiClusterNamespaces.ts
@@ -1,21 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-ui/kubevirt-api/console';
-import { MulticlusterResource } from '@kubevirt-utils/contexts/KubevirtPluginContext';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 
 import useKubevirtWatchResource from './useKubevirtWatchResource';
 
-type MultiClusterNamespaces = () => [MulticlusterResource<K8sResourceCommon[]>, boolean, any];
-
-const useMultiClusterNamespaces: MultiClusterNamespaces = () => {
-  const [namespaceData, loaded, error] = useKubevirtWatchResource<K8sResourceCommon[]>({
+const useMultiClusterNamespaces = () =>
+  useKubevirtWatchResource<K8sResourceCommon[]>({
     groupVersionKind: modelToGroupVersionKind(NamespaceModel),
     isList: true,
     limit: OBJECTS_FETCHING_LIMIT,
   });
-  return [namespaceData, loaded, error];
-};
 
 export default useMultiClusterNamespaces;

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -31,6 +31,7 @@ import {
   paginationInitialState,
 } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
+import { useSupportsMulticluster } from '@kubevirt-utils/hooks/useSupportsMulticluster';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   K8sResourceCommon,
@@ -219,6 +220,8 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef(
 
     const allVMsSelected = data?.length === selectedVMs.value.length;
 
+    const supportsMulticluster = useSupportsMulticluster();
+
     if (loaded && noVMs) {
       return (
         <>
@@ -246,9 +249,11 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef(
               <FlexItem>
                 <VirtualMachineBulkActionButton vms={data} />
               </FlexItem>
-              <FlexItem>
-                <VirtualMachinesCreateButton namespace={namespace} />
-              </FlexItem>
+              {!supportsMulticluster && (
+                <FlexItem>
+                  <VirtualMachinesCreateButton namespace={namespace} />
+                </FlexItem>
+              )}
             </Flex>
           </ListPageHeader>
         </div>

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -18,7 +18,7 @@ const VirtualMachineNavigator: FC = () => {
   useSignals();
   const { t } = useKubevirtTranslation();
   const childRef = useRef<{ onFilterChange: OnFilterChange } | null>(null);
-  const { isList, namespace, newVM, vmName } = useNavigatorLocationParams();
+  const { cluster, isList, namespace, newVM, vmName } = useNavigatorLocationParams();
 
   const treeProps = useTreeViewData();
 
@@ -40,7 +40,12 @@ const VirtualMachineNavigator: FC = () => {
   return (
     <VirtualMachineTreeView onFilterChange={onFilterChange} {...treeProps}>
       {isList ? (
-        <VirtualMachinesList kind={VirtualMachineModelRef} namespace={namespace} ref={childRef} />
+        <VirtualMachinesList
+          cluster={cluster}
+          kind={VirtualMachineModelRef}
+          namespace={namespace}
+          ref={childRef}
+        />
       ) : (
         <VirtualMachineNavPage kind={VirtualMachineModelRef} name={vmName} namespace={namespace} />
       )}

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import {
@@ -9,11 +9,12 @@ import {
   V1VirtualMachine,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import KubevirtPluginContext from '@kubevirt-utils/contexts/KubevirtPluginContext';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
-import { useGetResourceUrl } from '@kubevirt-utils/hooks/useGetResourceUrl';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
+import useMultiClusterNamespaces from '@kubevirt-utils/hooks/useMultiClusterNamespaces';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { useK8sWatchResource, useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
 import { TreeViewDataItem } from '@patternfly/react-core';
@@ -35,6 +36,9 @@ export const useTreeViewData = (): UseTreeViewData => {
 
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
+  const [namespaceNamesByCluster, namespaceNamesLoaded, namespaceNamesError] =
+    useMultiClusterNamespaces();
+  const { getResourceUrlOverride, supportsMulticluster } = useContext(KubevirtPluginContext);
 
   const [allVMs, allVMsLoaded] = useK8sWatchResource<V1VirtualMachine[]>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
@@ -42,10 +46,19 @@ export const useTreeViewData = (): UseTreeViewData => {
     limit: OBJECTS_FETCHING_LIMIT,
   });
 
+  const [multiclusterVms, multiclusterVmLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>({
+    groupVersionKind: VirtualMachineModelGroupVersionKind,
+    isList: true,
+    limit: OBJECTS_FETCHING_LIMIT,
+    namespace: undefined,
+    namespaced: true,
+  });
+
+  // when using multicluster we don't have to worry about this because search api will return all namespaces
   // user has limited access, so we can only get vms from allowed namespaces
   const allowedResources = useK8sWatchResources<{ [key: string]: V1VirtualMachine[] }>(
     Object.fromEntries(
-      projectNamesLoaded && !isAdmin
+      projectNamesLoaded && !isAdmin && !supportsMulticluster
         ? (projectNames || []).map((namespace) => [
             namespace,
             {
@@ -65,11 +78,12 @@ export const useTreeViewData = (): UseTreeViewData => {
     namespaced: true,
   });
 
+  // if multicluster, we should have access to all VMIM resources
   const allowedVMIMResources = useK8sWatchResources<{
     [key: string]: V1VirtualMachineInstanceMigration[];
   }>(
     Object.fromEntries(
-      projectNamesLoaded && !isAdmin
+      projectNamesLoaded && !isAdmin && !supportsMulticluster
         ? (projectNames || []).map((namespace) => [
             namespace,
             {
@@ -85,57 +99,70 @@ export const useTreeViewData = (): UseTreeViewData => {
   const memoizedVMIMs = useMemo(
     () =>
       getLatestMigrationForEachVM(
-        isAdmin
+        // is the || really necessary here?
+        isAdmin || supportsMulticluster
           ? allVMIM
           : Object.values(allowedVMIMResources).flatMap((resource) => resource.data),
       ),
-    [allVMIM, allowedVMIMResources, isAdmin],
+    [allVMIM, allowedVMIMResources, isAdmin, supportsMulticluster],
   );
 
   vmimMapperSignal.value = memoizedVMIMs;
 
   const memoizedVMs = useMemo(
-    () => (isAdmin ? allVMs : Object.values(allowedResources).flatMap((resource) => resource.data)),
-    [allVMs, allowedResources, isAdmin],
+    () =>
+      // is the || really necessary here?
+      isAdmin || supportsMulticluster
+        ? allVMs
+        : Object.values(allowedResources).flatMap((resource) => resource.data),
+    [allVMs, allowedResources, isAdmin, supportsMulticluster],
   );
-
   vmsSignal.value = memoizedVMs;
-
-  const getResourceUrl = useGetResourceUrl();
 
   const loaded =
     projectNamesLoaded &&
     (isAdmin ? allVMsLoaded : Object.values(allowedResources).some((resource) => resource.loaded));
+  const loadedMulticluster = multiclusterVmLoaded && namespaceNamesLoaded;
 
-  const treeData = useMemo(
-    () =>
-      loaded
-        ? createTreeViewData(
-            getResourceUrl,
-            projectNames,
-            memoizedVMs,
-            isAdmin,
-            location.pathname,
-            treeViewFoldersEnabled,
-          )
-        : [],
-    [
-      loaded,
-      getResourceUrl,
-      projectNames,
-      memoizedVMs,
-      isAdmin,
-      location.pathname,
-      treeViewFoldersEnabled,
-    ],
-  );
-
-  const isSwitchDisabled = useMemo(() => projectNames.every(isSystemNamespace), [projectNames]);
+  const memoizedtreeData = useMemo(() => {
+    const aggrigateClusterTreeData = [];
+    const activeProjectList = supportsMulticluster ? namespaceNamesByCluster : projectNames;
+    const activeVMsList = supportsMulticluster ? multiclusterVms : memoizedVMs;
+    if ((loaded && !supportsMulticluster) || loadedMulticluster) {
+      aggrigateClusterTreeData.push(
+        ...createTreeViewData(
+          getResourceUrlOverride,
+          isAdmin,
+          location.pathname,
+          treeViewFoldersEnabled,
+          activeProjectList,
+          activeVMsList,
+          supportsMulticluster,
+        ),
+      );
+    }
+    return aggrigateClusterTreeData;
+  }, [
+    supportsMulticluster,
+    namespaceNamesByCluster,
+    projectNames,
+    multiclusterVms,
+    memoizedVMs,
+    loaded,
+    loadedMulticluster,
+    getResourceUrlOverride,
+    isAdmin,
+    location.pathname,
+    treeViewFoldersEnabled,
+  ]);
+  const allNamespaces = namespaceNamesByCluster.map((namespace) => namespace.metadata.name);
+  const isSwitchDisabled = useMemo(() => allNamespaces?.every(isSystemNamespace), [allNamespaces]);
+  const treeData = [...memoizedtreeData] as TreeViewDataItem[];
 
   return {
     isSwitchDisabled,
     loaded,
-    loadError: projectNamesError,
+    loadError: projectNamesError || namespaceNamesError,
     treeData,
   };
 };

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -43,7 +43,7 @@ export const useTreeViewData = (): UseTreeViewData => {
     isList: true,
     limit: OBJECTS_FETCHING_LIMIT,
   });
-  debugger;
+
   // when using multicluster we don't have to worry about this because search api will return all namespaces
   // user has limited access, so we can only get vms from allowed namespaces
   const allowedResources = useK8sWatchResources<{ [key: string]: V1VirtualMachine[] }>(

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -15,8 +15,7 @@ import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
 import useMultiClusterNamespaces from '@kubevirt-utils/hooks/useMultiClusterNamespaces';
-import useProjects from '@kubevirt-utils/hooks/useProjects';
-import { useK8sWatchResource, useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
 import { TreeViewDataItem } from '@patternfly/react-core';
 import { getLatestMigrationForEachVM, OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 
@@ -35,36 +34,27 @@ export const useTreeViewData = (): UseTreeViewData => {
   const location = useLocation();
 
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
-  const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
   const [namespaceNamesByCluster, namespaceNamesLoaded, namespaceNamesError] =
     useMultiClusterNamespaces();
   const { getResourceUrlOverride, supportsMulticluster } = useContext(KubevirtPluginContext);
 
-  const [allVMs, allVMsLoaded] = useK8sWatchResource<V1VirtualMachine[]>({
+  const [allVMs, allVMsLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
     isList: true,
     limit: OBJECTS_FETCHING_LIMIT,
   });
-
-  const [multiclusterVms, multiclusterVmLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>({
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-    namespace: undefined,
-    namespaced: true,
-  });
-
+  debugger;
   // when using multicluster we don't have to worry about this because search api will return all namespaces
   // user has limited access, so we can only get vms from allowed namespaces
   const allowedResources = useK8sWatchResources<{ [key: string]: V1VirtualMachine[] }>(
     Object.fromEntries(
-      projectNamesLoaded && !isAdmin && !supportsMulticluster
-        ? (projectNames || []).map((namespace) => [
-            namespace,
+      namespaceNamesLoaded && !isAdmin && !supportsMulticluster
+        ? (namespaceNamesByCluster || []).map((namespace) => [
+            namespace.metadata.name,
             {
               groupVersionKind: VirtualMachineModelGroupVersionKind,
               isList: true,
-              namespace,
+              namespace: namespace.metadata.name,
             },
           ])
         : [],
@@ -83,13 +73,13 @@ export const useTreeViewData = (): UseTreeViewData => {
     [key: string]: V1VirtualMachineInstanceMigration[];
   }>(
     Object.fromEntries(
-      projectNamesLoaded && !isAdmin && !supportsMulticluster
-        ? (projectNames || []).map((namespace) => [
-            namespace,
+      namespaceNamesLoaded && !isAdmin && !supportsMulticluster
+        ? (namespaceNamesByCluster || []).map((namespace) => [
+            namespace.metadata.name,
             {
               groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
               isList: true,
-              namespace,
+              namespace: namespace.metadata.name,
             },
           ])
         : [],
@@ -99,7 +89,6 @@ export const useTreeViewData = (): UseTreeViewData => {
   const memoizedVMIMs = useMemo(
     () =>
       getLatestMigrationForEachVM(
-        // is the || really necessary here?
         isAdmin || supportsMulticluster
           ? allVMIM
           : Object.values(allowedVMIMResources).flatMap((resource) => resource.data),
@@ -111,58 +100,53 @@ export const useTreeViewData = (): UseTreeViewData => {
 
   const memoizedVMs = useMemo(
     () =>
-      // is the || really necessary here?
       isAdmin || supportsMulticluster
         ? allVMs
         : Object.values(allowedResources).flatMap((resource) => resource.data),
     [allVMs, allowedResources, isAdmin, supportsMulticluster],
   );
   vmsSignal.value = memoizedVMs;
+  const loaded = useMemo(() => {
+    if (!namespaceNamesLoaded) return false;
 
-  const loaded =
-    projectNamesLoaded &&
-    (isAdmin ? allVMsLoaded : Object.values(allowedResources).some((resource) => resource.loaded));
-  const loadedMulticluster = multiclusterVmLoaded && namespaceNamesLoaded;
-
-  const memoizedtreeData = useMemo(() => {
-    const aggrigateClusterTreeData = [];
-    const activeProjectList = supportsMulticluster ? namespaceNamesByCluster : projectNames;
-    const activeVMsList = supportsMulticluster ? multiclusterVms : memoizedVMs;
-    if ((loaded && !supportsMulticluster) || loadedMulticluster) {
-      aggrigateClusterTreeData.push(
-        ...createTreeViewData(
-          getResourceUrlOverride,
-          isAdmin,
-          location.pathname,
-          treeViewFoldersEnabled,
-          activeProjectList,
-          activeVMsList,
-          supportsMulticluster,
-        ),
-      );
+    if (isAdmin || supportsMulticluster) {
+      return allVMsLoaded;
     }
-    return aggrigateClusterTreeData;
-  }, [
-    supportsMulticluster,
-    namespaceNamesByCluster,
-    projectNames,
-    multiclusterVms,
-    memoizedVMs,
-    loaded,
-    loadedMulticluster,
-    getResourceUrlOverride,
-    isAdmin,
-    location.pathname,
-    treeViewFoldersEnabled,
-  ]);
+    return Object.values(allowedResources).some((resource) => resource.loaded);
+  }, [namespaceNamesLoaded, isAdmin, supportsMulticluster, allVMsLoaded, allowedResources]);
+
+  const treeData = useMemo(
+    () =>
+      loaded
+        ? createTreeViewData(
+            getResourceUrlOverride,
+            isAdmin,
+            location.pathname,
+            treeViewFoldersEnabled,
+            namespaceNamesByCluster,
+            memoizedVMs,
+            supportsMulticluster,
+          )
+        : [],
+    [
+      loaded,
+      getResourceUrlOverride,
+      isAdmin,
+      location.pathname,
+      treeViewFoldersEnabled,
+      namespaceNamesByCluster,
+      memoizedVMs,
+      supportsMulticluster,
+    ],
+  );
+
   const allNamespaces = namespaceNamesByCluster.map((namespace) => namespace.metadata.name);
   const isSwitchDisabled = useMemo(() => allNamespaces?.every(isSystemNamespace), [allNamespaces]);
-  const treeData = [...memoizedtreeData] as TreeViewDataItem[];
 
   return {
     isSwitchDisabled,
     loaded,
-    loadError: projectNamesError || namespaceNamesError,
+    loadError: namespaceNamesError,
     treeData,
   };
 };

--- a/src/views/virtualmachines/tree/hooks/useTreeViewSelect.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewSelect.ts
@@ -34,9 +34,6 @@ const useTreeViewSelect = (
 
   const onSelect = useCallback(
     (_event: MouseEvent, treeViewItem: TreeViewDataItemWithHref) => {
-      if (selected && selected.id === treeViewItem.id) {
-        setSelected(null);
-      }
       setSelected(treeViewItem);
       navigate(treeViewItem.href);
 
@@ -46,9 +43,13 @@ const useTreeViewSelect = (
         return onFilterChange?.(TEXT_FILTER_LABELS_ID, {
           all: [`${VM_FOLDER_LABEL}=${treeItemName}`],
         });
+      } else {
+        return onFilterChange?.(TEXT_FILTER_LABELS_ID, {
+          all: [],
+        });
       }
     },
-    [navigate, onFilterChange, selected, setOrRemoveQueryArgument],
+    [navigate, onFilterChange, setOrRemoveQueryArgument],
   );
 
   // Apply the selected item when reloading the page / creating project / creating VM / deleting VM

--- a/src/views/virtualmachines/tree/hooks/useTreeViewSelect.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewSelect.ts
@@ -34,6 +34,9 @@ const useTreeViewSelect = (
 
   const onSelect = useCallback(
     (_event: MouseEvent, treeViewItem: TreeViewDataItemWithHref) => {
+      if (selected && selected.id === treeViewItem.id) {
+        setSelected(null);
+      }
       setSelected(treeViewItem);
       navigate(treeViewItem.href);
 
@@ -45,7 +48,7 @@ const useTreeViewSelect = (
         });
       }
     },
-    [navigate, onFilterChange, setOrRemoveQueryArgument],
+    [navigate, onFilterChange, selected, setOrRemoveQueryArgument],
   );
 
   // Apply the selected item when reloading the page / creating project / creating VM / deleting VM

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -45,7 +45,7 @@ const groupByCluster = (resources: MulticlusterResource<any>[]) =>
 
 const buildProjectMap = (
   getResourceUrl: GetResourceUrl,
-  vms: MulticlusterResource<V1VirtualMachine>[] | V1VirtualMachine[],
+  vms: MulticlusterResource<V1VirtualMachine>[],
   currentPageVMName: string,
   currentVMTab: string,
   treeViewDataMap: Record<string, TreeViewDataItemWithHref>,
@@ -75,7 +75,7 @@ const buildProjectMap = (
         activeNamespace: vmNamespace,
         model: VirtualMachineModel,
         resource: { metadata: { name: vmName, namespace: vmNamespace } },
-      })}/${currentVMTab}`,
+      })}${currentVMTab ? `/${currentVMTab}` : ''}`,
       icon: <VMStatusIcon />,
       id: vmTreeItemID,
       name: vmName,


### PR DESCRIPTION
Multicluster treeview for kubevirt plugin
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description
These changes add conditional support for a multicluster VM treeview.

Some caveats: 
1. We may need to work on verifying the code that uses `vmimMapperSignal` is not broken by my changes and/or that we extend the features provided in `TreeViewRightClickActionMenu.tsx` to the multicluster tree data.  I have not verifies either, and I'm not sure that the right click action menu is currently enabled either, so I wonder if it is also a work-in-progress.
2. Empty project filtering is broken for multicluster ATM. I just wanted to get confirmation that displaying all projects for all spokes is the direction we wanted to take before giving it a shot.
3. There is likely more to be done to increase efficiency across the data loading and hooks in the `useTreeViewData.ts` module and the `utils.tsx`. I'm still feeling uneasy about them, but there's a lot of moving pieces, so it's difficult to feel confident quickly.
4. Multicluster project creation modal is next.

## 🎥 Demo
> Please add a video or an image of the behavior/changes
<img width="787" alt="Screenshot 2025-03-12 at 5 32 29 AM" src="https://github.com/user-attachments/assets/b389ec0a-ee64-4855-8e7c-7bd777c2c9f6" />



